### PR TITLE
Cat tweaks

### DIFF
--- a/python/catBCCA.py
+++ b/python/catBCCA.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 	parser = argparse.ArgumentParser()
 	parser.add_argument('sourceDir', type=str)
 	parser.add_argument('fileprefix', type=str)
-	parser.add.argument('fileprod', type=str)
+	parser.add_argument('fileprod', type=str)
 	parser.add_argument('outfolder', type=str)
 	args = parser.parse_args()
 	

--- a/python/catBCCA.py
+++ b/python/catBCCA.py
@@ -53,15 +53,15 @@ if __name__ == '__main__':
 		cmd = "ncdump -h "+file+" | grep UNLIMITED"
 		rtest = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
 		if(len(rtest.stdout.read()) == 0):
-			cmd = "ncecat -O -u time "+file+" "+file
+			cmd = "ncecat -h -O -u time "+file+" "+file
 			FNULL = open(os.devnull, 'w')
 			process = subprocess.call(cmd,shell=True,stdout=FNULL,stderr=subprocess.STDOUT)
-			cmd = "ncks -O --mk_rec_dmn time "+file+" "+file
+			cmd = "ncks -h -O --mk_rec_dmn time "+file+" "+file
 			FNULL = open(os.devnull, 'w')
 			process = subprocess.call(cmd,shell=True)#,stdout=FNULL,stderr=subprocess.STDOUT)
 	
 	
-	cmd = "ncrcat "+" ".join(files)+" "+fileprefix+"_merged.nc"
+	cmd = "ncrcat -h "+" ".join(files)+" "+fileprefix+"_"+fileprod+"_merged.nc"
 	process = subprocess.call(cmd,shell=True)
 	
 	cmd1 = "mv "+fileprefix+"* "+outfolder

--- a/python/parcatBCCA.py
+++ b/python/parcatBCCA.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 import shlex
 processes = []
-max_processes = 25
+max_processes = 4
 pause_time=2
 file_processing = 1
 files=("ACCESS1-0_rcp45_r1i1p1.nc",
@@ -141,24 +141,25 @@ files=("ACCESS1-0_rcp45_r1i1p1.nc",
 "bcc-csm1-1_rcp85_r1i1p1.nc",
 "inmcm4_rcp45_r1i1p1.nc",
 "inmcm4_rcp85_r1i1p1.nc")
-tasmax=True
-
-while file_processing<len(files):
-	print str(file_processing)
-	if tasmax:
-		command=shlex.split("python averageBCCA.py /Volumes/temp_striped/data/"+files[file_processing-1]+" BCCA_0-125deg_tasmax_day_"+files[file_processing-1].replace('.nc','')+" rcp "+files[file_processing-1].replace('.nc','')+"_tasmax /Volumes/temp_striped/")
-		tasmax=False
-	else:
-		command=shlex.split("python averageBCCA.py /Volumes/temp_striped/data/"+files[file_processing-1]+" BCCA_0-125deg_tasmin_day_"+files[file_processing-1].replace('.nc','')+" rcp "+files[file_processing-1].replace('.nc','')+"_tasmin /Volumes/temp_striped/")
+products=['monthly','annual', 'seasonal']
+temps=['tasmax','tasmin']
+commands=[]
+for i in range(len(files)):
+	for j in range(len(products)):
+		for k in range(len(temps)):
+			commands.append(shlex.split("python catBCCA.py /Volumes/temp_striped/ "+files[i].replace('.nc','')+"_"+temps[k]+" "+products[j]+" /Volumes/scratch2/out"))
+file_processing=0
+for command in commands:
+	while file_processing<len(commands):
+		print str(file_processing)
+		processes.append(subprocess.Popen(commands[file_processing]))
 		file_processing+=1
-		tasmax=True
-	processes.append(subprocess.Popen(command))
-	if len(processes) < max_processes:
-		time.sleep(pause_time)
-	while len(processes) >= max_processes:
-		time.sleep(pause_time*2)
-		processes = [proc for proc in processes if proc.poll() is None]
+		if len(processes) < max_processes:
+			time.sleep(pause_time)
+		while len(processes) >= max_processes:
+			time.sleep(pause_time*2)
+			processes = [proc for proc in processes if proc.poll() is None]
 
-while len(processes) > 0:
-	time.sleep(pause_time)
-	processes = [proc for proc in processes if proc.poll() is None]
+	while len(processes) > 0:
+		time.sleep(pause_time)
+		processes = [proc for proc in processes if proc.poll() is None]


### PR DESCRIPTION
@LarryBelcher With the runner script and minor other changes, I got this stuff to run, but I got some odd output. Nearly all the runs put a tmp file into the output directory. like: NorESM1-M_rcp45_r1i1p1_tasmin_monthly_merged.nc.pid13198.ncrcat.tmp

Each call also complained like this: mv: rename bcc-csm1-1_rcp60_r1i1p1_tasmin_monthly_merged.nc.pid26500.ncrcat.tmp to bcc-csm1-1_rcp60_r1i1p1_tasmin_monthly_merged.nc: No such file or directory
mv: rename bcc-csm1-1_rcp60_r1i1p1_tasmin\* to /Volumes/scratch2/out/bcc-csm1-1_rcp60_r1i1p1_tasmin*: No such file or directory

Any ideas? I also finished running all the base averages and the script was hung with some ncks commands sitting their unresponsive. 

I'm uploading the output files here: http://cida.usgs.gov/thredds/catalog/cmip5_bcca/derivatives/averages/catalog.html recognizing that this is incomplete, but just putting things there for tracking and for you to check over.
